### PR TITLE
ci: use actions/pypi-publish for test pypi publishing

### DIFF
--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -1,0 +1,50 @@
+---
+name: Upload Python Package to Test PyPI
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pypi-publish:
+    name: Upload release to Test PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/project/python-openobserve/
+    permissions:
+      id-token: write
+    steps:
+    # retrieve your distributions here
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build
+    - name: Build package
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
+      with:
+        repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
test target equivalent of https://github.com/JustinGuese/python-openobserve/pull/17

@JustinGuese  Please add repo workflow as publisher in pypi and testpypi if you can already. workflow python-publish.yml and python-publish-testpypi.yml.
https://docs.pypi.org/trusted-publishers/adding-a-publisher/
https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
Planning to tag 0.2.0 on Sunday.
