### PR TITLE
ci(python-publish-testpypi): add verbose and print-hash

### DIFF
--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -48,3 +48,5 @@ jobs:
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc
       with:
         repository-url: https://test.pypi.org/legacy/
+        verbose: true
+        print-hash: true


### PR DESCRIPTION
Follow-up of https://github.com/JustinGuese/python-openobserve/pull/21 as first run failed without much details
```
ERROR    HTTPError: 400 Bad Request from https://test.pypi.org/legacy/     
```
https://github.com/JustinGuese/python-openobserve/actions/runs/14824003219/job/41614737008#step:7:203