### PR TITLE
ci(python-publish-testpypi): push only on tags

### DIFF
--- a/.github/workflows/python-publish-testpypi.yml
+++ b/.github/workflows/python-publish-testpypi.yml
@@ -3,8 +3,6 @@ name: Upload Python Package to Test PyPI
 
 on:
   push:
-    branches:
-      - main
     tags:
       - '*'
   workflow_dispatch:


### PR DESCRIPTION
Follow-up of https://github.com/JustinGuese/python-openobserve/pull/21 and https://github.com/JustinGuese/python-openobserve/pull/22 as publish will fail if existing release/tag (even if removed)
```
title>400 This filename has already been used, use a different      
         version. See https://test.pypi.org/help/#file-name-reuse for more      
         information.</title>    
```